### PR TITLE
Refactored pull request checks

### DIFF
--- a/baldrick/plugins/github_milestones.py
+++ b/baldrick/plugins/github_milestones.py
@@ -1,5 +1,3 @@
-from flask import current_app
-
 from .github_pull_requests import pull_request_handler
 
 
@@ -12,6 +10,7 @@ def process_milestone(pr_handler, repo_handler):
     """
     A very simple set a failing status if the milestone is not set.
     """
+
     mc_config = repo_handler.get_config_value("milestones", None)
 
     if mc_config is None:
@@ -20,16 +19,7 @@ def process_milestone(pr_handler, repo_handler):
     fail_message = mc_config.get("missing_message", MISSING_MESSAGE)
     pass_message = mc_config.get("present_message", PRESENT_MESSAGE)
 
-    if not repo_handler.get_config_value('pull_requests', {}).get("post_pr_comment", False):
-        if not pr_handler.milestone:
-            pr_handler.set_status('failure', fail_message, current_app.bot_username + ": milestone")
-        else:
-            pr_handler.set_status('success', pass_message, current_app.bot_username + ": milestone")
-
-        return [], None
-
+    if pr_handler.milestone:
+        return {'milestone': (pass_message, True)}
     else:
-        if not pr_handler.milestone:
-            return [fail_message], False
-        else:
-            return [], True
+        return {'milestone': (fail_message, False)}

--- a/baldrick/plugins/github_milestones.py
+++ b/baldrick/plugins/github_milestones.py
@@ -20,6 +20,6 @@ def process_milestone(pr_handler, repo_handler):
     pass_message = mc_config.get("present_message", PRESENT_MESSAGE)
 
     if pr_handler.milestone:
-        return {'milestone': (pass_message, True)}
+        return {'milestone': {'message': pass_message, 'status': 'success'}}
     else:
-        return {'milestone': (fail_message, False)}
+        return {'milestone': {'message': fail_message, 'status': 'failure'}}

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -70,7 +70,7 @@ def process_pull_request(repository, number, installation):
     # certain events.
     pr_handler = PullRequestHandler(repository, number, installation)
 
-    pr_config = pr_handler.get_config_value("pull_requests", None)
+    pr_config = get_config_with_app_defaults(pr_handler, "pull_requests", {})
     post_comment = pr_config.get("post_pr_comment", False)
 
     # Disable if the config is not present

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -2,6 +2,7 @@ from flask import current_app
 
 from baldrick.github.github_api import RepoHandler, PullRequestHandler
 from baldrick.blueprints.github import github_webhook_handler
+from baldrick.plugins.utils import get_config_with_app_defaults
 
 __all__ = ['pull_request_handler']
 
@@ -23,11 +24,11 @@ def pull_request_handler(func):
     * demilestoned
 
     They will be passed ``(pr_handler, repo_handler)`` and are expected to
-    return ``messages, status` where messages is a list of strings to be
-    concatenated together with the prolog and epilogue to form a comment message
-    (if this is an empty list, no comment will be posted) and status is either a
-    boolean (`True` for PR passes, `False` for fail) or `None` for no status
-    check.
+    return a dictionary where the key is a unique string that refers to the
+    specific check that has been made, and the values are a tuple of
+    ``(message, status``), where ``message`` is the message to be shown in the
+    status or in the comment and ``status`` is a boolean that indicates whether
+    the build has succeeded (``True``) or failed (``False``).
     """
     PULL_REQUEST_CHECKS.append(func)
     return func
@@ -63,11 +64,13 @@ def handle_pull_requests(repo_handler, payload, headers):
 
 
 def process_pull_request(repository, number, installation):
+
     # TODO: cache handlers and invalidate the internal cache of the handlers on
     # certain events.
     pr_handler = PullRequestHandler(repository, number, installation)
 
     pr_config = pr_handler.get_config_value("pull_requests", None)
+    post_comment = pr_config.get("post_pr_comment", False)
 
     # Disable if the config is not present
     if pr_config is None:
@@ -92,38 +95,49 @@ def process_pull_request(repository, number, installation):
     else:
         comment_id = comment_ids[-1]
 
-    comments = []
-    set_status = False  # Do not send a status unless we need to.
-    status = True  # True is passing
+    results = {}
     for function in PULL_REQUEST_CHECKS:
-        f_comments, f_status = function(pr_handler, repo_handler)
-        if f_status is not None:
-            set_status = True
-            status = status and f_status
-        comments += f_comments
+        result = function(pr_handler, repo_handler)
+        results.update(result)
 
-    if comments:
-        message = current_app.pull_request_prolog.format(pr_handler=pr_handler, repo_handler=repo_handler)
-        message += ''.join(comments) + current_app.pull_request_epilog
-        comment_url = pr_handler.submit_comment(message, comment_id=comment_id,
-                                                return_url=True)
-    else:
-        all_passed_message = pr_config.get("all_passed_message", '')
-        all_passed_message = all_passed_message.format(pr_handler=pr_handler, repo_handler=repo_handler)
-        if all_passed_message:
-            pr_handler.submit_comment(all_passed_message, comment_id=comment_id)
+    failures = [message for message, status in results.values() if not status]
 
-        comment_url = None
-        message = ''
+    if post_comment:
 
-    if set_status:
-        if status:
-            pr_handler.set_status('success',
-                                  pr_config.get("pr_passed_status", "Passed all checks"),
-                                  current_app.bot_username, target_url=comment_url)
-        else:
+        # Post all failures in a comment, and have a single status check
+
+        if failures:
+
+            pull_request_prologue = get_config_with_app_defaults(pr_handler, 'pull_request_prologue', default='')
+            pull_request_epilogue = get_config_with_app_defaults(pr_handler, 'pull_request_epilogue', default='')
+
+            message = pull_request_prologue.format(pr_handler=pr_handler, repo_handler=repo_handler)
+            message += ''.join(failures) + pull_request_epilogue
+            comment_url = pr_handler.submit_comment(message, comment_id=comment_id,
+                                                    return_url=True)
+
             pr_handler.set_status('failure',
                                   pr_config.get("pr_failed_status", "Failed some checks"),
                                   current_app.bot_username, target_url=comment_url)
 
-    return message
+        else:
+
+            all_passed_message = pr_config.get("all_passed_message", '')
+            all_passed_message = all_passed_message.format(pr_handler=pr_handler, repo_handler=repo_handler)
+            if all_passed_message:
+                pr_handler.submit_comment(all_passed_message, comment_id=comment_id)
+
+            pr_handler.set_status('success',
+                                  pr_config.get("pr_passed_status", "Passed all checks"),
+                                  current_app.bot_username)
+
+    else:
+
+        # Post each failure as a status
+
+        for context, (message, status) in sorted(results.items()):
+
+            pr_handler.set_status('success' if status else 'failure', message,
+                                  current_app.bot_username + ':' + context)
+
+    return 'Finished pull requests checks'

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -155,28 +155,30 @@ def process_towncrier_changelog(pr_handler, repo_handler, headers):
 
     if skip_label and skip_label in pr_handler.labels:
 
-        messages['missing_file'] = 'Skipping changelog presence test', True
-        messages['wrong_type'] = 'Skipping changelog type test', True
-        messages['wrong_number'] = 'Skipping changelog number test', True
+        pass
 
     elif not matching_file:
 
-        messages['missing_file'] = NO_CHANGELOG, False
-        messages['wrong_type'] = 'Could not check changelog type', False
-        messages['wrong_number'] = 'Could not check changelog number', False
+        messages['missing_file'] = {'message': NO_CHANGELOG, 'status': 'failure'}
+        messages['wrong_type'] = {'message': 'Could not check changelog type', 'status': 'failure'}
+        messages['wrong_number'] = {'message': 'Could not check changelog number', 'status': 'failure'}
 
     else:
 
-        messages['missing_file'] = CHANGELOG, True
+        messages['missing_file'] = {'message': CHANGELOG, 'status': 'success'}
 
         if check_changelog_type(types, matching_file):
-            messages['wrong_type'] = CORRECT_TYPE, True
+            messages['wrong_type'] = {'message': CORRECT_TYPE, 'status': 'success'}
         else:
-            messages['wrong_type'] = WRONG_TYPE, False
+            messages['wrong_type'] = {'message': WRONG_TYPE, 'status': 'failure'}
 
         if cl_config.get('verify_pr_number', False) and not verify_pr_number(pr_handler.number, matching_file):
-            messages['wrong_number'] = WRONG_NUMBER, False
+            messages['wrong_number'] = {'message': WRONG_NUMBER, 'status': 'failure'}
         else:
-            messages['wrong_number'] = CORRECT_NUMBER, True
+            messages['wrong_number'] = {'message': CORRECT_NUMBER, 'status': 'success'}
+
+    # Add help URL
+    for message in messages:
+        message['target_url'] = cl_config.get('help_url', None)
 
     return messages

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -123,14 +123,14 @@ def verify_pr_number(pr_number, matching_file):
     return pr_number in matching_file
 
 
-CHANGELOG = "Changelog file was added in the correct directories."
-NO_CHANGELOG = "No changelog file was added in the correct directories."
+CHANGELOG_EXISTS = "Changelog file was added in the correct directories."
+CHANGELOG_MISSING = "No changelog file was added in the correct directories."
 
-CORRECT_TYPE = "The changelog file that was added is one of the configured types."
-WRONG_TYPE = "The changelog file that was added is not one of the configured types."
+TYPE_CORRECT = "The changelog file that was added is one of the configured types."
+TYPE_INCORRECT = "The changelog file that was added is not one of the configured types."
 
-CORRECT_NUMBER = "The number in the changelog file matches this pull request number."
-WRONG_NUMBER = "The number in the changelog file does not match this pull request number."
+NUMBER_CORRECT = "The number in the changelog file matches this pull request number."
+NUMBER_INCORRECT = "The number in the changelog file does not match this pull request number."
 
 
 @pull_request_handler
@@ -159,23 +159,28 @@ def process_towncrier_changelog(pr_handler, repo_handler, headers):
 
     elif not matching_file:
 
-        messages['missing_file'] = {'message': NO_CHANGELOG, 'status': 'failure'}
+        messages['missing_file'] = {'message': cl_config.get('changelog_missing', CHANGELOG_MISSING), 'status': 'failure'}
         messages['wrong_type'] = {'message': 'Could not check changelog type', 'status': 'failure'}
         messages['wrong_number'] = {'message': 'Could not check changelog number', 'status': 'failure'}
 
     else:
 
-        messages['missing_file'] = {'message': CHANGELOG, 'status': 'success'}
+        messages['missing_file'] = {'message': cl_config.get('changelog_exists', CHANGELOG_EXISTS),
+                                    'status': 'success'}
 
         if check_changelog_type(types, matching_file):
-            messages['wrong_type'] = {'message': CORRECT_TYPE, 'status': 'success'}
+            messages['wrong_type'] = {'message': cl_config.get('type_correct', TYPE_CORRECT),
+                                      'status': 'success'}
         else:
-            messages['wrong_type'] = {'message': WRONG_TYPE, 'status': 'failure'}
+            messages['wrong_type'] = {'message': cl_config.get('type_incorrect', TYPE_INCORRECT),
+                                      'status': 'failure'}
 
         if cl_config.get('verify_pr_number', False) and not verify_pr_number(pr_handler.number, matching_file):
-            messages['wrong_number'] = {'message': WRONG_NUMBER, 'status': 'failure'}
+            messages['wrong_number'] = {'message': cl_config.get('number_incorrect', NUMBER_INCORRECT),
+                                        'status': 'failure'}
         else:
-            messages['wrong_number'] = {'message': CORRECT_NUMBER, 'status': 'success'}
+            messages['wrong_number'] = {'message': cl_config.get('number_correc', NUMBER_CORRECT),
+                                        'status': 'success'}
 
     # Add help URL
     for message in messages:

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -9,10 +9,12 @@ test_hook = MagicMock()
 
 
 CONFIG_TEMPLATE = """
-[tool.testbot]
-[tool.testbot.pull_requests]
-post_pr_comment = {post_pr_comment}
-all_passed_message = {all_passed_message}
+[ tool.testbot ]
+  [ tool.testbot.pull_requests ]
+    post_pr_comment = {post_pr_comment}
+    all_passed_message = '{all_passed_message}'
+    fail_prologue = '{fail_prologue}'
+    fail_epilogue = '{fail_epilogue}'
 """
 
 
@@ -87,7 +89,8 @@ class TestPullRequestHandler:
 
         test_hook.return_value = {}
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
-                                                                     all_passed_message="''")
+                                                                     all_passed_message="''",
+                                                                     fail_prologue='', fail_epilogue='')
 
         self.send_event(client)
 
@@ -105,7 +108,8 @@ class TestPullRequestHandler:
 
         test_hook.return_value = {}
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
-                                                                     all_passed_message="'All checks passed'")
+                                                                     all_passed_message='All checks passed',
+                                                                     fail_prologue='', fail_epilogue='')
 
         self.send_event(client)
 
@@ -125,10 +129,11 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('No problem', True), 'test2': ('All good here', True)}
+        test_hook.return_value = {'test1': ('No problem', 'success'), 'test2': ('All good here', 'success')}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='false',
-                                                                     all_passed_message="'All checks passed'")
+                                                                     all_passed_message='All checks passed',
+                                                                     fail_prologue='', fail_epilogue='')
 
         self.send_event(client)
 
@@ -150,10 +155,11 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('No problem', True), 'test2': ('All good here', True)}
+        test_hook.return_value = {'test1': ('No problem', 'success'), 'test2': ('All good here', 'success')}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
-                                                                     all_passed_message="'All checks passed'")
+                                                                     all_passed_message='All checks passed',
+                                                                     fail_prologue='', fail_epilogue='')
 
         self.send_event(client)
 
@@ -173,10 +179,11 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('Problems here', False), 'test2': ('All good here', True)}
+        test_hook.return_value = {'test1': ('Problems here', 'failure'), 'test2': ('All good here', 'success')}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='false',
-                                                                     all_passed_message="'All checks passed'")
+                                                                     all_passed_message='All checks passed',
+                                                                     fail_prologue='', fail_epilogue='')
 
         self.send_event(client)
 
@@ -198,10 +205,11 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('Problems here', False), 'test2': ('All good here', True)}
+        test_hook.return_value = {'test1': ('Problems here', 'failure'), 'test2': ('All good here', 'success')}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
-                                                                     all_passed_message="'All checks passed'")
+                                                                     all_passed_message='All checks passed',
+                                                                     fail_prologue='', fail_epilogue='')
 
         self.send_event(client)
 
@@ -221,13 +229,12 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        app.pull_request_prologue_default = 'The prologue - '
-        app.pull_request_epilogue_default = ' - The epilogue'
-
-        test_hook.return_value = {'test1': ('Problems here', False), 'test2': ('All good here', True)}
+        test_hook.return_value = {'test1': ('Problems here', 'failure'), 'test2': ('All good here', 'success')}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
-                                                                     all_passed_message="'All checks passed'")
+                                                                     all_passed_message='All checks passed',
+                                                                     fail_prologue='The prologue - ',
+                                                                     fail_epilogue=' - The epilogue')
 
         self.send_event(client)
 

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -66,6 +66,8 @@ class TestPullRequestHandler:
             return req
         elif url == 'https://api.github.com/repos/test-repo/issues/1234/comments':
             req.json.return_value = self.pr_comments
+        elif url == 'https://api.github.com/repos/test-repo/commits/abc464aa/statuses':
+            req.json.return_value = {}
         else:
             raise ValueError('Unexepected URL: {0}'.format(url))
         return req
@@ -129,7 +131,8 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('No problem', 'success'), 'test2': ('All good here', 'success')}
+        test_hook.return_value = {'test1': {'message': 'No problem', 'status': 'success'},
+                                  'test2': {'message': 'All good here', 'status': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='false',
                                                                      all_passed_message='All checks passed',
@@ -155,7 +158,8 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('No problem', 'success'), 'test2': ('All good here', 'success')}
+        test_hook.return_value = {'test1': {'message': 'No problem', 'status': 'success'},
+                                  'test2': {'message': 'All good here', 'status': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
                                                                      all_passed_message='All checks passed',
@@ -179,7 +183,8 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('Problems here', 'failure'), 'test2': ('All good here', 'success')}
+        test_hook.return_value = {'test1': {'message': 'Problems here', 'status': 'failure'},
+                                  'test2': {'message': 'All good here', 'status': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='false',
                                                                      all_passed_message='All checks passed',
@@ -205,7 +210,8 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('Problems here', 'failure'), 'test2': ('All good here', 'success')}
+        test_hook.return_value = {'test1': {'message': 'Problems here', 'status': 'failure'},
+                                  'test2': {'message': 'All good here', 'status': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
                                                                      all_passed_message='All checks passed',
@@ -229,7 +235,8 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': ('Problems here', 'failure'), 'test2': ('All good here', 'success')}
+        test_hook.return_value = {'test1': {'message': 'Problems here', 'status': 'failure'},
+                                  'test2': {'message': 'All good here', 'status': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE.format(post_pr_comment='true',
                                                                      all_passed_message='All checks passed',

--- a/baldrick/plugins/utils.py
+++ b/baldrick/plugins/utils.py
@@ -3,7 +3,7 @@ from flask import current_app
 __all__ = ["get_config_with_app_defaults"]
 
 
-def get_config_with_app_defaults(repo_handler, config_section):
+def get_config_with_app_defaults(repo_handler, config_section, default=None):
     """
     Read the config section and check if the app has a default for that section.
 
@@ -12,5 +12,5 @@ def get_config_with_app_defaults(repo_handler, config_section):
     used if the section is not specified in the ``pyproject.toml`` file. If
     neither are specified then the plugin should not run.
     """
-    default_conf = getattr(current_app, config_section + "_default", None)
+    default_conf = getattr(current_app, config_section + "_default", default)
     return repo_handler.get_config_value(config_section, default_conf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@
   [ tool.baldrick.pull_requests ]
     post_pr_comment = true
     all_passed_message = ''
+    fail_prologue = ''
+    fail_epilogue = ''
+    fail_status = ''
+    pass_status = ''
    
   [ tool.baldrick.milestones ]
     missing_message = 'This pull request has no milestone set.'


### PR DESCRIPTION
This makes it so that handlers have to return a dictionary where the key is the 'context' and the value is a tuple of (message, status) - this can then be used to construct an overall comment or set individual statuses.

I've added tests for this but haven't checked that the changes to the towncrier and milestone plugin work.