### PR TITLE
Only declare dependencies in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,19 @@
-language: c
+language: python
 
 sudo: false
 
 os:
     - linux
 
-matrix:
-
-    include:
-        - env: PYTHON_VERSION=3.6
-               MAIN_CMD='pytest -rx --cov baldrick baldrick'
-               CONDA_DEPENDENCIES="pytest pytest-cov coverage requests flask cryptography python-dateutil toml"
-               PIP_DEPENDENCIES="coveralls flask-dance pygithub humanize codecov"
-
-        # Do a PEP8 test with flake8
-        - env: PYTHON_VERSION=3.6
-               MAIN_CMD='pytest --flake8 baldrick'
-               CONDA_DEPENDENCIES="pytest requests flask cryptography python-dateutil toml"
-               PIP_DEPENDENCIES="flask-dance pygithub humanize pytest-flake8 codecov"
+python:
+  - "3.6"
 
 install:
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda.sh
+    - pip install .[test]
 
 script:
-    - $MAIN_CMD
+    - pytest -rx --flake8 --cov baldrick baldrick
 
 after_success:
-    - if [[ $MAIN_CMD == *--cov* ]]; then codecov; fi;
+    - codecov
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(version='0.0.dev0',
       packages=find_packages(),
       author='Stuart Mumford and Thomas Robitaille',
       entry_points=entry_points,
-      extras_require={'test': ['pytest>=3.5', 'pytest-flake8', 'codecov']},
+      extras_require={'test': ['pytest>=3.5', 'pytest-flake8', 'pytest-cov', 'codecov']},
       install_requires=[
           "flask",
           "flask-dance",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(version='0.0.dev0',
       packages=find_packages(),
       author='Stuart Mumford and Thomas Robitaille',
       entry_points=entry_points,
-      extras_require={'test': ['pytest', 'pytest-flake8', 'codecov']},
+      extras_require={'test': ['pytest>=3.5', 'pytest-flake8', 'codecov']},
       install_requires=[
           "flask",
           "flask-dance",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(version='0.0.dev0',
       packages=find_packages(),
       author='Stuart Mumford and Thomas Robitaille',
       entry_points=entry_points,
+      extras_require={'test': ['pytest', 'pytest-flake8', 'codecov']},
       install_requires=[
           "flask",
           "flask-dance",


### PR DESCRIPTION
Why do complicated when we can do simple...

I guess we need to keep requirements.txt for Heroku? Or not?