### PR TITLE
Fix bug that occurred when an unrelated status exists on the pull request

### DIFF
--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -180,9 +180,10 @@ def process_pull_request(repository, number, installation):
         # status to pass and set message to say skipped
 
         for full_context in existing_statuses:
-            context = full_context[len(current_app.bot_username) + 1:]
-            if context not in results:
-                pr_handler.set_status('success', 'This check has been skipped',
-                                      current_app.bot_username + ':' + context)
+            if full_context.startswith(current_app.bot_username + ':'):
+                context = full_context[len(current_app.bot_username) + 1:]
+                if context not in results:
+                    pr_handler.set_status('success', 'This check has been skipped',
+                                          current_app.bot_username + ':' + context)
 
     return 'Finished pull requests checks'

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -302,11 +302,13 @@ class TestPullRequestHandler:
 
         self.existing_statuses = [{'context': 'testbot:test1',
                                    'description': 'Problems here',
-                                   'state': 'pending'}]
-
-        self.existing_statuses = [{'context': 'testbot:test2',
+                                   'state': 'pending'},
+                                  {'context': 'testbot:test2',
                                    'description': 'All good here (extra comment)',
-                                   'state': 'success'}]
+                                   'state': 'success'},
+                                  {'context': 'travis',
+                                   'description': 'An unrelated status',
+                                   'state': 'failure'}]
 
         self.send_event(client)
 


### PR DESCRIPTION
For example if a pull request had a status from Travis or other CI services